### PR TITLE
Latest block as block height

### DIFF
--- a/chains.ts
+++ b/chains.ts
@@ -20,7 +20,7 @@ const chains = {
     1666600000: {
         id: 1666600000,
         name: 'harmony',
-        rpc: 'https://a.api.s0.t.hmny.io',
+        rpc: 'https://rpc.s0.t.hmny.io',
         blockinterval: 3
     },
     137: {

--- a/server/helpers/blocks.ts
+++ b/server/helpers/blocks.ts
@@ -27,8 +27,7 @@ const smartBinaryBlockSearch = async (chain: any, timestamp: number) => {
 
     let blockInterval = chain.blockinterval;
 
-    let result = await recursiveSearch(currentBlock, timestamp, blockInterval, provider);
-
+    let result = currentBlock.timestamp <= timestamp ? currentBlock.number : await recursiveSearch(currentBlock, timestamp, blockInterval, provider);
 
     let resp = {
         chain: chain.id,


### PR DESCRIPTION
When 'latest' block from an RPC is previous or equal to desired timestamp, return it at corresponding chain height for the underlying chain.